### PR TITLE
Add missing anchor

### DIFF
--- a/software-i-use.html
+++ b/software-i-use.html
@@ -213,7 +213,7 @@ email to <code>plans@tripit.com</code> and it will create an account
 from your email address.
 </div>
 
-<h2>iPhone / iPad apps</h2>
+<h2 id="ipad">iPhone / iPad apps</h2>
 
 <p>
 A lot of the iPad apps that I like are companions to either a desktop or a Web app that I use.


### PR DESCRIPTION
I do not think anybody will notice, but the "iPad apps" link was not doing anything.